### PR TITLE
Fixed bug in level serializer that resulted in levels not merging

### DIFF
--- a/Newton's Gumball Ralley/Assets/Scripts/Core/LevelSerializer.cs
+++ b/Newton's Gumball Ralley/Assets/Scripts/Core/LevelSerializer.cs
@@ -38,7 +38,7 @@ namespace Core
     public static class LevelSerializer
     {
         public static readonly string WRITE_DIRECTORY_PATH =
-            Application.persistentDataPath + "/LevelsData/";
+            Application.streamingAssetsPath + "/LevelsData/";
 
         private static readonly string BACKGROUND_KEY = "Background";
         private static readonly string ENVIRONMENT_KEY = "Environment";

--- a/Newton's Gumball Ralley/Assets/StreamingAssets.meta
+++ b/Newton's Gumball Ralley/Assets/StreamingAssets.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: aa9eeb0fbe152da4cbfa4e1fb8ccf8e4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Newton's Gumball Ralley/Assets/StreamingAssets/LevelData.meta
+++ b/Newton's Gumball Ralley/Assets/StreamingAssets/LevelData.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 73be20cd2d9e7f04faf8763017cfae8e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Newton's Gumball Ralley/Assets/StreamingAssets/LevelsData.meta
+++ b/Newton's Gumball Ralley/Assets/StreamingAssets/LevelsData.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 26cf9469bc083f244b550b5869351415
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Previously, the level serializer's write path used `Application.persistentDataPath`, but this is actually meant for saving local player data, not files that are meant to be common among all builds of the game, including and especially level data. Since `Application.persistentDataPath` points to somewhere in the user's local files, level designers can't presently include their changes in the repo for the purposes of commiting them. So I changed where levels save:
- Added new folders Assets/StreamingAssets and Assets/StreamingAssets/LevelData
- Updated level serializer to write there instead of locally