### PR TITLE
Fixed level serializer not working for Mac

### DIFF
--- a/Newton's Gumball Ralley/Assets/Scripts/Core/LevelSerializer.cs
+++ b/Newton's Gumball Ralley/Assets/Scripts/Core/LevelSerializer.cs
@@ -47,7 +47,7 @@ namespace Core
     public static class LevelSerializer
     {
         public static readonly string WRITE_DIRECTORY_PATH =
-            Application.dataPath + "/LevelsData/";
+            Path.Combine(Application.dataPath, "LevelsData");
 
         private static readonly string MANAGERS_KEY = "Managers";
         private static readonly string BACKGROUND_MANAGER_KEY = "Background Manager";
@@ -81,11 +81,14 @@ namespace Core
             string writeFilePath = WRITE_DIRECTORY_PATH;
             if (customLevelName.Equals(""))
             {
-                writeFilePath += worldIndex.ToString() + "-" + levelIndex.ToString();
+                writeFilePath = Path.Combine(
+                    writeFilePath,
+                    worldIndex.ToString() + "-" + levelIndex.ToString()
+                );
             }
             else
             {
-                writeFilePath += customLevelName;
+                writeFilePath = Path.Combine(writeFilePath, customLevelName);
             }
             writeFilePath += ".json";
             Directory.CreateDirectory(WRITE_DIRECTORY_PATH);


### PR DESCRIPTION
- updated level serializer to use System.IO.Path.Combine for an OS-agnostic write path